### PR TITLE
fix passing settings to `Optimizer` and add test

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -82,11 +82,11 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
         sense = MOI.MIN_SENSE
         objconstant = zero(T)
         rowranges = Dict{Int, UnitRange{Int}}()
-
+        optimizer = new(inner,has_results,is_empty,sense,objconstant,rowranges)
         for (key, value) in user_settings
-            MOI.set(optimizer, MOI.RawOptimizerAttribute(key), value)
+            MOI.set(optimizer, MOI.RawOptimizerAttribute(string(key)), value)
         end
-        new(inner,has_results,is_empty,sense,objconstant,rowranges)
+        return optimizer
     end
 end
 

--- a/test/Interfaces/MOI_wrapper_tests.jl
+++ b/test/Interfaces/MOI_wrapper_tests.jl
@@ -91,7 +91,13 @@ function test_SolverName()
     return
 end
 
+function test_passing_settings()
+    optimizer = Clarabel.Optimizer{T}(; verbose=false)
+    @test optimizer.inner.settings.verbose === false
+    return
+end
+
 end # module TestClarabel
 
-# This line at tne end of the file runs all the tests!
+# This line at the end of the file runs all the tests!
 TestClarabel.runtests()


### PR DESCRIPTION
This wasn't working due to keyword arguments being symbols and `MOI.RawOptimizerAttribute` expecting strings, and the variable `optimizer` wasn't defined in the code.