### PR TITLE
cholmod and mkl as optional deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,24 +8,30 @@ AMD = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 QDLDL = "bfc457fd-c171-5ab7-bd9e-d5dbfc242d63"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 AMD = "0.4, 0.5"
 DataFrames = "1"
 MathOptInterface = "1.2"
-Pardiso = "0.5"
 PrettyTables = "0.12, 1"
 QDLDL = "0.3"
+Requires = "^1"
 StaticArrays = "1"
 TimerOutputs = "0.5"
 julia = "1.2"
+
+[extras]
+Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
+SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[targets]
+test = ["Pardiso","SuiteSparse"]

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
@@ -31,7 +32,6 @@ julia = "1.2"
 
 [extras]
 Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
-SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [targets]
-test = ["Pardiso","SuiteSparse"]
+test = ["Pardiso"]

--- a/src/Clarabel.jl
+++ b/src/Clarabel.jl
@@ -56,14 +56,15 @@ module Clarabel
     include("./utils/mathutils.jl")
     include("./utils/csc_assembly.jl")
 
-    #optional dependencies 
+    #optional dependencies.  
+    #NB: This __init__ function and its @require statements 
+    #should be removed upon update of this package for use 
+    #with Julia v1.10+, after which weakdeps / external 
+    #dependencies will be natively supported 
     function __init__()
         @require Pardiso="46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2" begin
             include("./kktsolvers/direct-ldl/directldl_mklpardiso.jl")  
         end 
-        @require SuiteSparse="4607b0f0-06f3-5cda-b6b1-a6196a1729e9" begin
-            include("./kktsolvers/direct-ldl/directldl_cholmod.jl")
-        end
     end
 
     #MathOptInterface for JuMP/Convex.jl

--- a/src/Clarabel.jl
+++ b/src/Clarabel.jl
@@ -1,6 +1,7 @@
+__precompile__()
 module Clarabel
 
-    using SparseArrays, LinearAlgebra, Printf
+    using SparseArrays, LinearAlgebra, Printf, Requires
     const DefaultFloat = Float64
     const DefaultInt   = LinearAlgebra.BlasInt
     const IdentityMatrix = UniformScaling{Bool}
@@ -55,6 +56,16 @@ module Clarabel
     include("./utils/mathutils.jl")
     include("./utils/csc_assembly.jl")
 
+    #optional dependencies 
+    function __init__()
+        @require Pardiso="46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2" begin
+            include("./kktsolvers/direct-ldl/directldl_mklpardiso.jl")  
+        end 
+        @require SuiteSparse="4607b0f0-06f3-5cda-b6b1-a6196a1729e9" begin
+            include("./kktsolvers/direct-ldl/directldl_cholmod.jl")
+        end
+    end
+
     #MathOptInterface for JuMP/Convex.jl
     module MOImodule
          include("./MOI_wrapper/MOI_wrapper.jl")
@@ -62,3 +73,4 @@ module Clarabel
     const Optimizer{T} = Clarabel.MOImodule.Optimizer{T}
 
 end
+

--- a/src/kktsolvers/direct-ldl/directldl_cholmod.jl
+++ b/src/kktsolvers/direct-ldl/directldl_cholmod.jl
@@ -1,3 +1,4 @@
+using SuiteSparse
 mutable struct CholmodDirectLDLSolver{T} <: AbstractDirectLDLSolver{T}
 
     F::Union{SuiteSparse.CHOLMOD.Factor,Nothing}

--- a/src/kktsolvers/direct-ldl/directldl_cholmod.jl
+++ b/src/kktsolvers/direct-ldl/directldl_cholmod.jl
@@ -1,5 +1,3 @@
-using SuiteSparse
-
 mutable struct CholmodDirectLDLSolver{T} <: AbstractDirectLDLSolver{T}
 
     F::Union{SuiteSparse.CHOLMOD.Factor,Nothing}

--- a/src/kktsolvers/direct-ldl/directldl_mklpardiso.jl
+++ b/src/kktsolvers/direct-ldl/directldl_mklpardiso.jl
@@ -1,4 +1,3 @@
-import Pardiso
 using AMD
 
 struct PardisoDirectLDLSolver{T} <: AbstractDirectLDLSolver{T}

--- a/src/kktsolvers/direct-ldl/includes.jl
+++ b/src/kktsolvers/direct-ldl/includes.jl
@@ -1,6 +1,7 @@
 
 include("./directldl_defaults.jl")
 include("./directldl_qdldl.jl")
-include("./directldl_mklpardiso.jl")  
-include("./directldl_cholmod.jl")
 include("./directldl_utils.jl")
+
+#NB: MKL and Cholmod / Suitesparse are optional dependencies 
+#and are loaded via Requires.jl in the main Clarabel module 

--- a/src/kktsolvers/direct-ldl/includes.jl
+++ b/src/kktsolvers/direct-ldl/includes.jl
@@ -1,7 +1,8 @@
 
 include("./directldl_defaults.jl")
 include("./directldl_qdldl.jl")
+include("./directldl_cholmod.jl")
 include("./directldl_utils.jl")
 
-#NB: MKL and Cholmod / Suitesparse are optional dependencies 
-#and are loaded via Requires.jl in the main Clarabel module 
+#NB: MKL is an optional dependency and is 
+#loaded via Requires.jl in the main Clarabel module 


### PR DESCRIPTION
Makes Pardiso package optional using Requires.jl.

In order to use the :mkl solver option, it is now necessary to load Pardiso before loading Clarabel.

This is a temporary fix until new support of conditional dependencies appears in Julia v.1.10