### PR TITLE
Suggest tolerance documentation update

### DIFF
--- a/src/settings.jl
+++ b/src/settings.jl
@@ -16,24 +16,24 @@ verbose                                 | true      | verbose printing
 max\\_step\\_fraction                   | 0.99      | maximum interior point step length
 ||
 __Full Accuracy Settings__||
-tol\\_gap\\_abs                         | 1e-8      | absolute residual tolerance
-tol\\_gap\\_rel                         | 1e-8      | relative residual tolerance
-tol\\_feas                              | 1e-8      | feasibility check tolerance
-tol\\_infeas\\_abs						| 1e-8		| absolute infeasibility tolerance
-tol\\_infeas\\_rel						| 1e-8		| relative infeasibility tolerance
+tol\\_gap\\_abs                         | 1e-8      | absolute duality-gap tolerance
+tol\\_gap\\_rel                         | 1e-8      | relative duality-gap tolerance
+tol\\_feas                              | 1e-8      | feasibility check tolerance (primal and dual)
+tol\\_infeas\\_abs						| 1e-8		| absolute infeasibility tolerance (primal and dual)
+tol\\_infeas\\_rel						| 1e-8		| relative infeasibility tolerance (primal and dual)
 tol\\_ktratio                           | 1e-7      | κ/τ tolerance
 ||
 __Reduced Accuracy Settings__||
-reduced\\_tol\\_gap\\_abs               | 5e-5      | reduced absolute residual tolerance
-reduced\\_tol\\_gap\\_rel               | 5e-5      | reduced relative residual tolerance
-reduced\\_tol\\_feas                    | 1e-4      | reduced feasibility check tolerance
-reduced\\_tol\\_infeas_abs		        | 5e-5      | reduced absolute infeasibility tolerance
-reduced\\_tol\\_infeas_rel		        | 5e-5      | reduced relative infeasibility tolerance
+reduced\\_tol\\_gap\\_abs               | 5e-5      | reduced absolute duality-gap tolerance
+reduced\\_tol\\_gap\\_rel               | 5e-5      | reduced relative duality-gap tolerance
+reduced\\_tol\\_feas                    | 1e-4      | reduced feasibility check tolerance (primal and dual)
+reduced\\_tol\\_infeas_abs		        | 5e-5      | reduced absolute infeasibility tolerance (primal and dual)
+reduced\\_tol\\_infeas_rel		        | 5e-5      | reduced relative infeasibility tolerance (primal and dual)
 reduced\\_tol\\_ktratio                 | 1e-4      | reduced κ/τ tolerance
 ||
 __Data Equilibration Settings__||
 ||
-equilibrate\\_enable                    | true      | enable  data equilibration pre-scaling
+equilibrate\\_enable                    | true      | enable data equilibration pre-scaling
 equilibrate\\_max\\_iter                | 10        | maximum equilibration scaling iterations
 equilibrate\\_min\\_scaling             | 1e-4      | minimum equilibration scaling allowed
 equilibrate\\_max\\_scaling             | 1e+4      | maximum equilibration scaling allowed


### PR DESCRIPTION
Small suggestion for the tolerance labels in the docs.

- At first I was confused that `tol_gap` referred to a "residual", which sounds like a primal or dual residual. It should be less ambiguous to refer to the duality gap directly.
- Small precision between brackets that the feasibility checks both primal and dual residuals. Feel free to scrap.