### PR TITLE
Update README.md for JuMP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,11 @@ Interior Point Conic Optimization for Julia
 
 __Clarabel.jl__ is a Julia implementation of an interior point numerical solver for convex optimization problems using a novel homogeneous embedding.  Clarabel.jl solves the following problem:
 
-$$
-\begin{array}{r}
+$$\begin{array}{r}
 \text{minimize} & \frac{1}{2}x^T P x + q^T x\\\\[2ex]
  \text{subject to} & Ax + s = b \\\\[1ex]
         & s \in \mathcal{K}
- \end{array}
-$$
+\end{array}$$
 
 with decision variables
 $x \in \mathbb{R}^n$,
@@ -50,12 +48,12 @@ Clarabel is also available in a Rust / Python implementation.  See [here](https:
 * __Versatile__: Clarabel.jl solves linear programs (LPs), quadratic programs (QPs), second-order cone programs (SOCPs) and semidefinite programs (SDPs).  It also solves problems with exponential and power cone constraints.
 * __Quadratic objectives__: Unlike interior point solvers based on the standard homogeneous self-dual embedding (HSDE), Clarabel.jl handles quadratic objectives without requiring any epigraphical reformulation of the objective.   It can therefore be significantly faster than other HSDE-based solvers for problems with quadratic objective functions.
 * __Infeasibility detection__: Infeasible problems are detected using a homogeneous embedding technique.
-* __JuMP / Convex.jl support__: We provide an interface to [MathOptInterface](https://jump.dev/JuMP.jl/stable/moi/) (MOI), which allows you to describe your problem in [JuMP](https://github.com/JuliaOpt/JuMP.jl) and [Convex.jl](https://github.com/JuliaOpt/Convex.jl).
-* __Arbitrary precision types__: You can solve problems with any floating point precision, e.g. Float32 or Julia's BigFloat type, using either the native interface, or via MathOptInterface / Convex.jl.
+* __JuMP / Convex.jl support__: We provide an interface to [MathOptInterface](https://jump.dev/JuMP.jl/stable/moi/) (MOI), which allows you to describe your problem in [JuMP](https://github.com/jump-dev/JuMP.jl) and [Convex.jl](https://github.com/jump-dev/Convex.jl).
+* __Arbitrary precision types__: You can solve problems with any floating point precision, for example, Float32 or Julia's BigFloat type, using either the native interface, or via MathOptInterface / Convex.jl.
 * __Open Source__: Our code is available on [GitHub](https://github.com/oxfordcontrol/Clarabel.jl) and distributed under the Apache 2.0 License
 
 ## Installation
 - __Clarabel.jl__ can be added via the Julia package manager (type `]`): `pkg> add Clarabel`
 
 ## License 🔍
-This project is licensed under the Apache License  2.0 - see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the Apache License  2.0 - see the [LICENSE.md](https://github.com/oxfordcontrol/Clarabel.jl/blob/main/LICENSE.md) file for details.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Interior Point Conic Optimization for Julia
 
 __Clarabel.jl__ is a Julia implementation of an interior point numerical solver for convex optimization problems using a novel homogeneous embedding.  Clarabel.jl solves the following problem:
 
-$$\begin{array}{r}
+$$
+\begin{array}{r}
 \text{minimize} & \frac{1}{2}x^T P x + q^T x\\\\[2ex]
- \text{subject to} & Ax + s = b \\\\[1ex]
+\text{subject to} & Ax + s = b \\\\[1ex]
         & s \in \mathcal{K}
-\end{array}$$
+\end{array}
+$$
 
 with decision variables
 $x \in \mathbb{R}^n$,


### PR DESCRIPTION
I'm adding solver READMEs to the JuMP documentation: https://github.com/jump-dev/JuMP.jl/pull/3366

Here's what it currently looks like: https://jump.dev/JuMP.jl/previews/PR3366/packages/Clarabel/. I still need to fix the image loading.

The documentation build runs a linter with the Google documentation style guide, which requires things like no latin abbreviations, and because the docs will appear in the JuMP repo, the local license link won't work.