### PR TITLE
Scaledpsd

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 AMD = "0.4, 0.5"
 GenericLinearAlgebra = "0.3"
-MathOptInterface = "1.2"
+MathOptInterface = "1.6"
 QDLDL = "0.4"
 Requires = "1"
 SnoopPrecompile = "1"


### PR DESCRIPTION
This new cone was just added in MOI v1.6. This allows simplifying the MOI wrapper of many SDP solver but it also allows passing scaled PSD cone data directly to the solver.