### PR TITLE
Pg/soc small cones speedup

### DIFF
--- a/src/kktsystem.jl
+++ b/src/kktsystem.jl
@@ -94,7 +94,7 @@ function kkt_solve_initial_point!(
     data::DefaultProblemData{T}
 ) where{T}
 
-    if true || iszero(nnz(data.P))
+    if iszero(nnz(data.P))
         # LP initialization
         # solve with [0;b] as a RHS to get (x,-s) initializers
         # zero out any sparse cone variables at end

--- a/src/kktsystem.jl
+++ b/src/kktsystem.jl
@@ -94,14 +94,15 @@ function kkt_solve_initial_point!(
     data::DefaultProblemData{T}
 ) where{T}
 
-    if iszero(nnz(data.P))
+    if true || iszero(nnz(data.P))
         # LP initialization
-        # solve with [0;b] as a RHS to get (x,s) initializers
+        # solve with [0;b] as a RHS to get (x,-s) initializers
         # zero out any sparse cone variables at end
         kktsystem.workx .= zero(T)
         kktsystem.workz .= data.b
         kktsolver_setrhs!(kktsystem.kktsolver, kktsystem.workx, kktsystem.workz)
         is_success = kktsolver_solve!(kktsystem.kktsolver, variables.x, variables.s)
+        variables.s .= -variables.s
 
         if !is_success return is_success end
 


### PR DESCRIPTION
Improves numerical efficiency in problems with a large number of small SOCs by removing @views in favor of explicit loops with @inbounds.