### PR TITLE
Update GitHub action scripts

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,12 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,14 @@
 name: ci
 on:
-  - pull_request
-  - workflow_dispatch
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
@@ -9,36 +16,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - version: '1.10'
-            os: ubuntu-latest
-            arch: x64
-          - version: '1.10'
-            os: macos-latest
-            arch: x64
-          - version: '1.10'
-            os: windows-latest
-            arch: x64
+        version: ['1.10', '1']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [x64]
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
       

--- a/test/OptTests/basic_exp.jl
+++ b/test/OptTests/basic_exp.jl
@@ -1,10 +1,10 @@
-using Test, LinearAlgebra, SparseArrays, Random
+using Test, LinearAlgebra, SparseArrays
 
 #if not run in full test setup, just do it for one float type
 @isdefined(UnitTestFloats) || (UnitTestFloats = [Float64])
 
 function basic_exp_data(Type::Type{T}) where {T <: AbstractFloat}
- 
+
     #x is of dimension 7
     n = 7
     A1 = hcat(ones(T,1,3), zeros(T,1,4))        #ZeroCone

--- a/test/OptTests/basic_socp.jl
+++ b/test/OptTests/basic_socp.jl
@@ -1,11 +1,11 @@
-using Test, LinearAlgebra, SparseArrays, Random
+using Test, LinearAlgebra, SparseArrays, StableRNGs
 
 #if not run in full test setup, just do it for one float type
 @isdefined(UnitTestFloats) || (UnitTestFloats = [Float64])
 
 function basic_SOCP_data(Type::Type{T}) where {T <: AbstractFloat}
 
-    rng = Random.MersenneTwister(242713)
+    rng = StableRNGs.StableRNG(242713)
     n = 3
     P = randn(rng,n,n)*1
     P = SparseMatrixCSC{T}(convert(Matrix{T},(P'*P)))
@@ -43,18 +43,19 @@ end
 
                 @test solver.solution.status == Clarabel.SOLVED
                 @test isapprox(
-                norm(solver.solution.x -
-                FloatT[ -0.5 ; 0.435603 ;  -0.245459]),
-                zero(FloatT), atol=tol)
-                @test isapprox(solver.solution.obj_val, FloatT(-8.4590e-01), atol=tol)
-                @test isapprox(solver.solution.obj_val_dual, FloatT(-8.4590e-01), atol=tol)
+                    norm(solver.solution.x - FloatT[-0.127715, 0.108242, -0.067784]),
+                    zero(FloatT);
+                    atol=tol,
+                )
+                @test isapprox(solver.solution.obj_val, FloatT(-0.148520), atol=tol)
+                @test isapprox(solver.solution.obj_val_dual, FloatT(-0.148520), atol=tol)
 
 
             end
 
             @testset "feasible_sparse" begin
 
-                # same data, but with one SOC cone so that we get the 
+                # same data, but with one SOC cone so that we get the
                 # sparse representation for code coverage
                 P,c,A,b,cones = basic_SOCP_data(FloatT)
                 cones = Clarabel.SupportedCone[Clarabel.NonnegativeConeT(3), Clarabel.NonnegativeConeT(6)]

--- a/test/OptTests/linear_solvers.jl
+++ b/test/OptTests/linear_solvers.jl
@@ -2,10 +2,10 @@ using Test, LinearAlgebra, SparseArrays
 
 #Test each of these solvers, but only for Float64
 
-#NB: mkl fails here because of some weird library 
+#NB: mkl fails here because of some weird library
 #issue caused by loading conflicting BLAS libraries.
-#:mkl works, but not if you are also testing 
-#JuMP.  Issue here: 
+#:mkl works, but not if you are also testing
+#JuMP.  Issue here:
 # https://github.com/JuliaSparse/Pardiso.jl/issues/88
 
 SolverTypes = [:qdldl, :cholmod]
@@ -37,10 +37,10 @@ for SolverType in SolverTypes
             @test solver.solution.status == Clarabel.SOLVED
             @test isapprox(
                 norm(solver.solution.x -
-                FloatT[ -0.5 ; 0.435603 ;  -0.245459]),
+                FloatT[-0.127715, 0.108242, -0.067784]),
                 zero(FloatT), atol=tol
             )
-            @test isapprox(solver.solution.obj_val, FloatT(-8.4590e-01), atol=tol)
+            @test isapprox(solver.solution.obj_val, FloatT(-0.148520), atol=tol)
 
         end
 

--- a/test/OptTests/socp-lasso.jl
+++ b/test/OptTests/socp-lasso.jl
@@ -1,4 +1,4 @@
-using Test, LinearAlgebra, Random, SparseArrays
+using Test, LinearAlgebra, SparseArrays, StableRNGs
 
 #only test this once
 FloatT = Float64
@@ -10,7 +10,7 @@ function SOCP_lasso_data(Type::Type{T}) where {T <: AbstractFloat}
     #instances will have different optimal values
 
     # generate problem data
-    rng = Random.MersenneTwister(12345)
+    rng = StableRNGs.StableRNG(12345)
     n = 8
     m = 50 * n
     F = rand(rng, T, m, n)
@@ -61,7 +61,7 @@ tol = FloatT(1e-3)
     Clarabel.solve!(solver)
 
     @test solver.solution.status == Clarabel.SOLVED
-    @test isapprox(solver.solution.obj_val, -5.0233e+00, atol=tol)
+    @test isapprox(solver.solution.obj_val, -4.7081728e+02, atol=tol)
 
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,10 +3,11 @@ Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Convex = "0.15"
-JuMP = "0.2, 1"
+JuMP = "1"
+StableRNGs = "1"

--- a/test/UnitTests/test_coneops_psdtrianglecone.jl
+++ b/test/UnitTests/test_coneops_psdtrianglecone.jl
@@ -1,6 +1,6 @@
-using Test, LinearAlgebra, SparseArrays, Clarabel, Random
+using Test, LinearAlgebra, SparseArrays, Clarabel, StableRNGs
 
-rng = Random.MersenneTwister(242713)
+rng = StableRNGs.StableRNG(242713)
 
 FloatT = Float64
 
@@ -11,8 +11,8 @@ FloatT = Float64
         K = Clarabel.PSDTriangleCone(5)
         @test Clarabel.numel(K)== 15
         @test Clarabel.degree(K) == 5
-        @test_throws DomainError Clarabel.PSDTriangleCone(-1) 
-        
+        @test_throws DomainError Clarabel.PSDTriangleCone(-1)
+
 
     end
 
@@ -169,7 +169,7 @@ FloatT = Float64
         eS = eigvals(S + αs.*dS)
         @test minimum([eZ;eS]) ≈ 0.  atol = sqrt(eps(FloatT))
 
-        #should reach maximum step 
+        #should reach maximum step
         dS .= randpsd(rng,n); dZ .= randpsd(rng,n)
         map((v,M)->Clarabel.mat_to_svec!(v,M),(ds,dz),(dS,dZ))
         (αz,αs) = Clarabel.step_length(K,dz,ds,z,s,settings,1.0)

--- a/test/UnitTests/test_coneops_secondordercone.jl
+++ b/test/UnitTests/test_coneops_secondordercone.jl
@@ -1,6 +1,6 @@
-using Test, LinearAlgebra, SparseArrays, Clarabel, Random
+using Test, LinearAlgebra, SparseArrays, Clarabel, StableRNGs
 
-rng = Random.MersenneTwister(242713)
+rng = StableRNGs.StableRNG(242713)
 
 FloatT = Float64
 
@@ -17,8 +17,8 @@ FloatT = Float64
 
     @testset "test_coneops_scaled_unit_shift" begin
 
-        n = 5 
-        s = randn(n)
+        n = 5
+        s = randn(rng, n)
         s[1] = -1.
         K = Clarabel.SecondOrderCone(5)
         (m,_) = Clarabel.margins(K,s,Clarabel.PrimalCone)
@@ -32,8 +32,8 @@ FloatT = Float64
 
         n = 5  #must be > 4 to avoid dense representation
         K = Clarabel.SecondOrderCone(n)
-        s = randn(n)
-        z = randn(n)
+        s = randn(rng, n)
+        z = randn(rng, n)
         (mz,_) = Clarabel.margins(K,z,Clarabel.DualCone)
         corz = mz > 0. ? 0. : 1. -mz
         (ms,_) = Clarabel.margins(K,s,Clarabel.PrimalCone)
@@ -59,7 +59,7 @@ FloatT = Float64
         #this should be W^TW
         W2_A = η^2 .* (D + u*u' - v*v')
 
-        #W^TW should agree with Hinv 
+        #W^TW should agree with Hinv
         J = -I(n).*1.; J[1,1] = 1.
         Hinv = η^2 .* (2*w*w' - J)
 
@@ -80,14 +80,14 @@ FloatT = Float64
         # W_B should be symmetric
         @test norm(W_B-W_B') ≈ 0     atol = 1e-14
 
-        #matrix and its inverse should agree 
+        #matrix and its inverse should agree
         @test norm(W_B*W_Binv - I(n)) ≈ 0     atol = 1e-14
 
         # square should agree with the directly constructed one
         W2_B = W_B*W_B
         @test norm(W2_B-W2_A) ≈ 0     atol = 1e-12
 
-        
+
     end
 
 

--- a/test/run_component_tests.jl
+++ b/test/run_component_tests.jl
@@ -1,4 +1,4 @@
-using Random, Test
+using Test
 
 @testset "Clarabel Unit Tests" begin
 
@@ -6,7 +6,7 @@ using Random, Test
     include("./UnitTests/test_coneops_psdtrianglecone.jl")
     include("./UnitTests/test_coneops_secondordercone.jl")
 
-    #tests on constructors 
+    #tests on constructors
     include("./UnitTests/test_constructors.jl")
 
     #tests on equilibration
@@ -15,7 +15,7 @@ using Random, Test
     #tests on json IO
     include("./UnitTests/test_json.jl")
 
-    #tests on cone simplification and merging 
+    #tests on cone simplification and merging
     include("./UnitTests/test_cones_new_collapsed.jl")
 
 end

--- a/test/run_interface_tests.jl
+++ b/test/run_interface_tests.jl
@@ -1,4 +1,4 @@
-using Random, Test
+using Test
 using Clarabel
 
 @testset "Clarabel Interfaces Testset" begin

--- a/test/run_solver_tests.jl
+++ b/test/run_solver_tests.jl
@@ -1,4 +1,4 @@
-using Random, Test
+using Test
 using Clarabel
 
 UnitTestFloats = [Float64,BigFloat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
- using Random, Test, Clarabel
+ using Test, Clarabel
 include("./testing_utils.jl")
 
 @testset "Clarabel Tests" begin


### PR DESCRIPTION
Clarabel has been failing our solver-tests.yml job for a while: https://github.com/jump-dev/MathOptInterface.jl/actions/runs/14371008998/job/40297204676

But you won't have noticed because the CI job tests only v1.10.

Also, CI was running only on PRs, and not on pushes to `main`: https://github.com/oxfordcontrol/Clarabel.jl/commits/main/

I assume this will cause the v1 tests to fail, so I'll see if I can fix them. Either in this PR or in a new one.