### PR TITLE
Add min-fill ordering.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.10.0"
 
 [deps]
 AMD = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"
+CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -29,6 +30,7 @@ PardisoExt = "Pardiso"
 
 [compat]
 AMD = "0.4, 0.5"
+CliqueTrees = "1.5.1"
 DataStructures = "0.18"
 GenericLinearAlgebra = "0.3"
 HSL = "0.4, 0.5"

--- a/src/chordal/chordal_info.jl
+++ b/src/chordal/chordal_info.jl
@@ -1,3 +1,5 @@
+import CliqueTrees
+
 # -------------------------------------
 # Chordal Decomposition Information
 # -------------------------------------
@@ -235,19 +237,18 @@ function find_graph!(nz_mask::AbstractVector{Bool})
             push!(cols, col)
         end
     end
-    
+
     # QDLDL doesn't currently allow for logical-only decomposition 
     # on a matrix of Bools, so pattern must be a Float64 matrix here
     pattern = sparse(rows, cols, ones(Float64, length(rows)), n, n)
-
-	F = QDLDL.qdldl(pattern, logical = true)
-
+    
+    perm, _ = CliqueTrees.permutation(Symmetric(pattern, :U); alg=CliqueTrees.MF())
+    F = QDLDL.qdldl(pattern; perm, logical = true)
     L = F.L
     ordering = F.perm
-
-	# this takes care of the case that QDLDL returns an unconnected adjacency matrix L
-	connect_graph!(L)
-
+    
+    # this takes care of the case that QDLDL returns an unconnected adjacency matrix L
+    connect_graph!(L)
     return L, ordering 
 end
 


### PR DESCRIPTION
You are currently using the AMD algorithm to compute elimination orderings (as part of your clique tree machinery). AMD is a great linear-time algorithm, but there are quadratic-time algorithms that compute orderings with less fill. This PR replaces AMD with the minimum-local-fill algorithm. On some problems, the difference in solve time is dramatic.

```julia-repl
julia> using Clarabel, ClarabelBenchmarks
```

**AMD**

```julia-repl
julia> ClarabelBenchmarks.PROBLEMS["sdplib"]["arch0"](Clarabel.Optimizer);
-------------------------------------------------------------
           Clarabel.jl v0.10.0  -  Clever Acronym              

                   (c) Paul Goulart                          
                University of Oxford, 2022                   
-------------------------------------------------------------
[...]
Terminated with status = solved
solve time =  21.8s
```

**Minimum-Local-Fill**

```julia-repl
julia> ClarabelBenchmarks.PROBLEMS["sdplib"]["arch0"](Clarabel.Optimizer);
-------------------------------------------------------------
           Clarabel.jl v0.10.0  -  Clever Acronym              

                   (c) Paul Goulart                          
                University of Oxford, 2022                   
-------------------------------------------------------------
[...]
Terminated with status = solved
solve time =  3.06s
```

I omitted the greater part of the printout.