### PR TITLE
Allow newer versions of JSON and DataStructures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,10 +29,10 @@ PardisoExt = "Pardiso"
 
 [compat]
 AMD = "0.4, 0.5"
-DataStructures = "0.18"
+DataStructures = "0.18, 0.19"
 GenericLinearAlgebra = "0.3"
 HSL = "0.4, 0.5"
-JSON = "0.21"
+JSON = "0.21, 1"
 MathOptInterface = "1.20"
 Pardiso = "0.5.6,1"
 QDLDL = "0.4.1"


### PR DESCRIPTION
I'm trying to update another package to use JSON 1.0, it would be great if Clarabel could be updated to support it.

All tests pass locally, but I didn't investigate deeply if you are using any sophisticated JSON functionality that needs to be checked further.