### PR TITLE
Upgrades to CUDSS.jl 0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ PardisoExt = "Pardiso"
 
 [compat]
 AMD = "0.4, 0.5"
-CUDSS = "0.5"
+CUDSS = "0.6"
 DataStructures = "0.18"
 GenericLinearAlgebra = "0.3"
 HSL = "0.4, 0.5"

--- a/src/kktsolvers/gpu/directldl_cudss.jl
+++ b/src/kktsolvers/gpu/directldl_cudss.jl
@@ -45,7 +45,7 @@ end
 function refactor!(ldlsolver::CUDSSDirectLDLSolver{T}) where{T}
 
     # Update the KKT matrix in the cudss solver
-    cudss_set(ldlsolver.cudssSolver.matrix,ldlsolver.KKT)
+    cudss_update(ldlsolver.cudssSolver.matrix,ldlsolver.KKT)
 
     # Refactorization
     cudss("factorization", ldlsolver.cudssSolver, ldlsolver.x, ldlsolver.b)

--- a/src/kktsolvers/gpu/directldl_mixed_cudss.jl
+++ b/src/kktsolvers/gpu/directldl_mixed_cudss.jl
@@ -53,7 +53,7 @@ function refactor!(ldlsolver::CUDSSDirectLDLSolverMixed{T}) where{T}
     copyto!(ldlsolver.KKTFloat32.nzVal,ldlsolver.KKT.nzVal)
 
     # Update the KKT matrix in the cudss solver
-    cudss_set(ldlsolver.cudssSolver.matrix,ldlsolver.KKTFloat32)
+    cudss_update(ldlsolver.cudssSolver.matrix,ldlsolver.KKTFloat32)
 
     # Refactorization
     cudss("factorization", ldlsolver.cudssSolver, ldlsolver.xFloat32, ldlsolver.bFloat32)


### PR DESCRIPTION
Upgrades the CUDSS.jl library to 0.6. This is necessary to support System CUDA 13.0 and more recent versions of CUDA.jl.