### PR TITLE
Remove usage of getindex(::OrderedSet, ::Int)

### DIFF
--- a/src/chordal/decomposition/psd_completion.jl
+++ b/src/chordal/decomposition/psd_completion.jl
@@ -7,18 +7,18 @@
 # positive semidefinite completion routine to choose the values
 
 function psd_completion!(
-    chordal_info::ChordalInfo{T}, 
+    chordal_info::ChordalInfo{T},
     variables::AbstractVariables{T}
 ) where {T}
 
     # working now with the cones from the original
-    # problem, not the decomposed ones 
+    # problem, not the decomposed ones
     cones = chordal_info.init_cones
 
     # loop over psd cones
     row_ranges = collect(rng_cones_iterator(cones))
 
-    # loop over just the patterns 
+    # loop over just the patterns
     for pattern in chordal_info.spatterns
         row_range = row_ranges[pattern.orig_index]
         z = @view variables.z[row_range]
@@ -36,7 +36,7 @@ function complete!(z::AbstractVector{T},pattern::SparsityPattern) where{T}
     psd_complete!(Z,pattern)
     mat_to_svec!(z,Z)
 
-end 
+end
 
 # positive semidefinite completion (from Vandenberghe - Chordal Graphs..., p. 362)
 # input: A - positive definite completable matrix
@@ -47,32 +47,32 @@ function psd_complete!(A::AbstractMatrix{T}, pattern::SparsityPattern) where {T 
     ip = invperm(p)
     N  = size(A,2)
 
-    # PJG: not clear if this copy of A is required, or 
-    # whether I can operate directly on A by permuting the 
-    # the indices in the loops below.  Only worth doing that 
+    # PJG: not clear if this copy of A is required, or
+    # whether I can operate directly on A by permuting the
+    # the indices in the loops below.  Only worth doing that
     # if copying in or out of A is expensive.
 
     # permutate matrix based on ordering p
     # W is in the order that the cliques are based on
     W = A[p, p]
 
-    # go through supernode tree in descending order (given a post-ordering). 
+    # go through supernode tree in descending order (given a post-ordering).
     # This is ensured in the get_snode, get_separators functions
 
     for j = (sntree.n_cliques - 1):-1:1
 
-        # in order to obtain ν, α the vertex numbers of the supernode are 
+        # in order to obtain ν, α the vertex numbers of the supernode are
         # mapped to the new position of the permuted matrix index
         # set of snd(i) sorted using the numerical ordering i,i+1,...i+ni
         ν = get_snode(sntree, j)
 
-        # index set containing the elements of col(i) \ snd(i) 
+        # index set containing the elements of col(i) \ snd(i)
         #sorted using numerical ordering σ(i)
         α = get_separators(sntree, j)
 
-        # index set containing the row indices of the lower-triangular zeros in 
+        # index set containing the row indices of the lower-triangular zeros in
         # column i (i: representative index) sorted by σ(i)
-        i = ν[1]
+        i = _getindex(ν, 1)
 
         ν = collect(ν) #unborks indexing below
         α = collect(α) #unborks indexing below

--- a/src/chordal/types.jl
+++ b/src/chordal/types.jl
@@ -1,15 +1,27 @@
-# DataStructures provides OrderedSet, but only because it itself includes 
-# OrderedCollections.  Could just use OrderedCollections directly, 
+# DataStructures provides OrderedSet, but only because it itself includes
+# OrderedCollections.  Could just use OrderedCollections directly,
 # but the kruskal! function also uses a function from DataStructures.
-# If that is removed then use the lighter weight option here 
+# If that is removed then use the lighter weight option here
 
 using DataStructures
 
 abstract type AbstractMergeStrategy end
 VertexSet = OrderedSet{DefaultInt}
 
+# OrderedCollections@2 removed getindex(::OrderedSet, ::Int). As a work-around,
+# use this method, as suggested here:
+# https://github.com/JuliaCollections/DataStructures.jl/pull/180#issuecomment-484877416
+function _getindex(set::VertexSet, index::DefaultInt)
+    for (i, si) in enumerate(set)
+        if i == index
+            return si
+        end
+    end
+    return throw(BoundsError(set, index))
+end
+
 #PJG: make a settable option
-@enum EdgeWeightMethod begin 
+@enum EdgeWeightMethod begin
   CUBIC = 1
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,5 +8,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Convex = "0.15"
-JuMP = "0.2, 1"
+Convex = "0.15, 0.16"
+JuMP = "1"


### PR DESCRIPTION
Clarabel depends on DataStructures.jl, which depends on OrderedCollections.jl.

OrderedCollections@2 introduced a breaking change that removed this method: https://github.com/JuliaCollections/DataStructures.jl/pull/180#issuecomment-484877416

It wasn't found in tests of Clarabel because JuMP and MathOptInterface had dependencies on OrderedCollections@1. They're relaxing that compat to add support for OrderedCollections@2, exposing this bug.